### PR TITLE
feat: min duty log time config entry

### DIFF
--- a/config/server.lua
+++ b/config/server.lua
@@ -1,6 +1,6 @@
 return {
     discordWebhook = nil, -- Replace nil with your webhook if you chose to use discord logging over ox_lib logging
-
+    minOnDutyLogTimeMinutes = 30,
 	formatDateTime = '%m-%d-%Y %H:%M',
 
     -- While the config boss menu creation still works, it is recommended to use the runtime export instead.

--- a/server/main.lua
+++ b/server/main.lua
@@ -236,14 +236,13 @@ exports('RegisterBossMenu', registerBossMenu)
 ---@param citizenid string
 ---@param job string
 local function doPlayerCheckIn(source, citizenid, job)
-	playersClockedIn[source] = { citizenid = citizenid, job = job }
-	OnPlayerCheckIn(citizenid, job)
+	playersClockedIn[source] = { citizenid = citizenid, job = job, time = os.time() }
 end
 
 ---@param source number
 local function onPlayerUnload(source)
 	if playersClockedIn[source] then
-        OnPlayerCheckOut(playersClockedIn[source].citizenid)
+        OnPlayerCheckOut(playersClockedIn[source])
 		playersClockedIn[source] = nil
     end
 end


### PR DESCRIPTION
- adds config value for determining the minimum session time in minutes for logging. Duty times shorter than this will not be logged
- Switches from writing clock in and clock out to the database separately, to storing clock in in memory only, and writing to the database only when the session is complete.